### PR TITLE
Bump obs-websocket-js-5 from 5.0.2 to 5.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "jsonwebtoken": "^9.0.0",
         "jspack": "^0.0.4",
         "obs-websocket-js": "npm:obs-websocket-js@^4.0.3",
-        "obs-websocket-js-5": "npm:obs-websocket-js@^5.0.2",
+        "obs-websocket-js-5": "npm:obs-websocket-js@^5.0.3",
         "osc": "^2.4.3",
         "packet": "0.0.6",
         "rate-limiter-flexible": "^2.3.7",


### PR DESCRIPTION
https://github.com/obs-websocket-community-projects/obs-websocket-js/releases/tag/v5.0.3